### PR TITLE
Fixes #74 - Add API Pagination for Orders

### DIFF
--- a/app/(api)/_datalib/_resolvers/Order.ts
+++ b/app/(api)/_datalib/_resolvers/Order.ts
@@ -8,7 +8,7 @@ const resolvers = {
       Orders.getProducts(parent.id, ctx),
   },
   Query: {
-    order: (_: never, args: { id: string }, ctx: ApolloContext) =>
+    order: (_: never, args: { id: number }, ctx: ApolloContext) =>
       Orders.find(args.id, ctx),
     orders: (
       _: never,
@@ -25,27 +25,27 @@ const resolvers = {
   Mutation: {
     updateOrder: (
       _: never,
-      args: { id: string; input: OrderInput },
+      args: { id: number; input: OrderInput },
       ctx: ApolloContext
     ) => Orders.update(args.id, args.input, ctx),
-    deleteOrder: (_: never, args: { id: string }, ctx: ApolloContext) =>
+    deleteOrder: (_: never, args: { id: number }, ctx: ApolloContext) =>
       Orders.delete(args.id, ctx),
     createOrder: (_: never, args: { input: OrderInput }, ctx: ApolloContext) =>
       Orders.create(args.input, ctx),
     addProductToOrder: (
       _: never,
-      args: { id: string; productToAdd: OrderProductInput },
+      args: { id: number; productToAdd: OrderProductInput },
       ctx: ApolloContext
     ) => Orders.addProductToOrder(args.id, args.productToAdd, ctx),
     removeProductFromOrder: (
       _: never,
-      args: { id: string; product_id: string },
+      args: { id: number; product_id: string },
       ctx: ApolloContext
     ) => Orders.removeProductFromOrder(args.id, args.product_id, ctx),
     editProductQuantity: (
       _: never,
       args: {
-        id: string;
+        id: number;
         productToUpdate: OrderProductInput;
       },
       ctx: ApolloContext

--- a/app/(api)/_datalib/_resolvers/Order.ts
+++ b/app/(api)/_datalib/_resolvers/Order.ts
@@ -10,8 +10,11 @@ const resolvers = {
   Query: {
     order: (_: never, args: { id: string }, ctx: ApolloContext) =>
       Orders.find(args.id, ctx),
-    orders: (_: never, args: { ids: string[] }, ctx: ApolloContext) =>
-      Orders.findMany(args.ids, ctx),
+    orders: (
+      _: never,
+      args: { statuses: string[]; offset: number; limit: number },
+      ctx: ApolloContext
+    ) => Orders.findMany(args.statuses, args.offset, args.limit, ctx),
   },
   Mutation: {
     updateOrder: (

--- a/app/(api)/_datalib/_resolvers/Order.ts
+++ b/app/(api)/_datalib/_resolvers/Order.ts
@@ -12,9 +12,15 @@ const resolvers = {
       Orders.find(args.id, ctx),
     orders: (
       _: never,
-      args: { statuses: string[]; offset: number; limit: number },
+      args: {
+        statuses: string[];
+        search: string;
+        offset: number;
+        limit: number;
+      },
       ctx: ApolloContext
-    ) => Orders.findMany(args.statuses, args.offset, args.limit, ctx),
+    ) =>
+      Orders.findMany(args.statuses, args.search, args.offset, args.limit, ctx),
   },
   Mutation: {
     updateOrder: (

--- a/app/(api)/_datalib/_services/Orders.ts
+++ b/app/(api)/_datalib/_services/Orders.ts
@@ -31,19 +31,29 @@ export default class Orders {
     });
   }
 
-  static async findMany(ids: string[], ctx: ApolloContext) {
+  static async findMany(
+    statuses: string[],
+    offset: number,
+    limit: number,
+    ctx: ApolloContext
+  ) {
     if (!ctx.isOwner && !ctx.hasValidApiKey) return null;
 
-    if (!ids) {
-      return prisma.order.findMany();
-    }
+    if (offset < 0 || limit <= 0) return null; // TODO: Possible some better error message.
+
+    /*
+      If statuses is null, or has no length, then do not filter by statuses.
+     */
+    const filter =
+      !statuses || statuses.length > 0 ? { status: { in: statuses } } : {};
 
     return prisma.order.findMany({
-      where: {
-        id: {
-          in: ids,
-        },
+      where: filter,
+      orderBy: {
+        created_at: 'desc',
       },
+      skip: offset * limit,
+      take: limit,
     });
   }
 

--- a/app/(api)/_datalib/_typeDefs/Order.ts
+++ b/app/(api)/_datalib/_typeDefs/Order.ts
@@ -67,7 +67,12 @@ const typeDefs = gql`
 
   type Query {
     order(id: ID!): Order
-    orders(statuses: [String], offset: Int!, limit: Int!): [Order]
+    orders(
+      statuses: [String]
+      search: String
+      offset: Int!
+      limit: Int!
+    ): [Order]
   }
 
   type Mutation {

--- a/app/(api)/_datalib/_typeDefs/Order.ts
+++ b/app/(api)/_datalib/_typeDefs/Order.ts
@@ -67,7 +67,7 @@ const typeDefs = gql`
 
   type Query {
     order(id: ID!): Order
-    orders(id: [ID]): [Order]
+    orders(statuses: [String], offset: Int!, limit: Int!): [Order]
   }
 
   type Mutation {

--- a/app/(api)/_types/Order.ts
+++ b/app/(api)/_types/Order.ts
@@ -1,7 +1,7 @@
 import { Product } from './Product';
 
 export type Order = {
-  id: string;
+  id: number;
   customer_name: string;
   customer_email: string;
   customer_phone_num: string;
@@ -23,7 +23,7 @@ export type Order = {
 export type ProductToOrder = {
   product_id: string;
   product: Product;
-  order_id: string;
+  order_id: number;
   order: Order;
   quantity: number;
 };

--- a/prisma/migrations/20250625001334_order_id_autoincrement/migration.sql
+++ b/prisma/migrations/20250625001334_order_id_autoincrement/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - The primary key for the `Order` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `Order` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `ProductToOrder` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - Changed the type of `order_id` on the `ProductToOrder` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- DropForeignKey
+ALTER TABLE "ProductToOrder" DROP CONSTRAINT "ProductToOrder_order_id_fkey";
+
+-- AlterTable
+ALTER TABLE "Order" DROP CONSTRAINT "Order_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" SERIAL NOT NULL,
+ADD CONSTRAINT "Order_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "ProductToOrder" DROP CONSTRAINT "ProductToOrder_pkey",
+DROP COLUMN "order_id",
+ADD COLUMN     "order_id" INTEGER NOT NULL,
+ADD CONSTRAINT "ProductToOrder_pkey" PRIMARY KEY ("product_id", "order_id");
+
+-- AddForeignKey
+ALTER TABLE "ProductToOrder" ADD CONSTRAINT "ProductToOrder_order_id_fkey" FOREIGN KEY ("order_id") REFERENCES "Order"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema/Order.prisma
+++ b/prisma/schema/Order.prisma
@@ -1,5 +1,5 @@
 model Order {
-  id                      String           @id @default(uuid())
+  id                      Int              @id @default(autoincrement())
   customer_name           String
   customer_email          String
   customer_phone_num      String

--- a/prisma/schema/ProductToOrder.prisma
+++ b/prisma/schema/ProductToOrder.prisma
@@ -1,7 +1,7 @@
 model ProductToOrder {
   product_id String
   product    Product @relation(fields: [product_id], references: [id], onDelete: Cascade)
-  order_id   String
+  order_id   Int
   order      Order   @relation(fields: [order_id], references: [id], onDelete: Cascade)
   quantity   Int
 


### PR DESCRIPTION
This fixes #74. Adds pagination for the orders query with GraphQL and Prisma. It was tested with the following queries (which all appear to be working properly).

```graphql
query GetLast10Orders {
  orders(offset: 0, limit: 10) {
    id,
    customer_name,
    status
    created_at,
  }
}

query GetLast10DeliveredOrders {
  orders(statuses: ["delivered"], offset: 0, limit: 10) {
    id,
    customer_name,
    status,
    created_at
  }
}

query GetLast10OrdersWithOffset {
  orders(offset: 1, limit: 10) {
    id,
    customer_name,
    status,
    created_at
  }
}
```